### PR TITLE
Add work-dir option + Allow to use the script standalone

### DIFF
--- a/git-subsplit.sh
+++ b/git-subsplit.sh
@@ -71,6 +71,7 @@ subsplit_main()
 			--update) UPDATE=1 ;;
 			-n) DRY_RUN="--dry-run" ;;
 			--dry-run) DRY_RUN="--dry-run" ;;
+			--work-dir) WORK_DIR="$1"; shift ;;
 			--rebuild-tags) REBUILD_TAGS=1 ;;
 			--) break ;;
 			*) die "Unexpected option: $opt" ;;

--- a/git-subsplit.sh
+++ b/git-subsplit.sh
@@ -345,4 +345,9 @@ subsplit_update()
 	popd >/dev/null
 }
 
+if [ "$(basename -- "$0")" == "git-subsplit.sh" ];
+then
+    shift
+fi
+
 subsplit_main "$@"


### PR DESCRIPTION
Hey!

This PR fixes the work-dir option which seems just documented and it also allows to use the script as standalone by removing the script name from the args (otherwise the script name is used as command option).
