### PR TITLE
Search for matching branches, not only fixed names

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ branches the upstream repository knows about.
 Do not sync any heads.
 
 
+#### --search-heads
+
+To search for a list of possible heads and publish only the matches.
+
+    --search-heads="refs/heads/master\|refs/heads/develop\|refs/heads/release-"
+
+The above will only publish branches that are either `master`, `develop`
+or any other branch of the form `release-*`.
+
+[Grep](https://www.gnu.org/savannah-checkouts/gnu/grep/manual/grep.html) patterns will be applied.
+
+
 #### --tags=\<tags\>
 
 To specify a list of tags (instead of letting git-subsplit discover them

--- a/git-subsplit.sh
+++ b/git-subsplit.sh
@@ -21,6 +21,7 @@ work-dir      directory that contains the subsplit working directory
 
  options for 'publish'
 heads=        only publish for listed heads instead of all heads
+search-heads= search and only publish matching heads instead of all heads (grep pattern)
 no-heads      do not publish any heads
 tags=         only publish for listed tags instead of all tags
 no-tags       do not publish any tags
@@ -49,6 +50,7 @@ SPLITS=
 REPO_URL=
 WORK_DIR="${PWD}/.subsplit"
 HEADS=
+SEARCH_HEADS=
 NO_HEADS=
 TAGS=
 NO_TAGS=
@@ -65,6 +67,7 @@ subsplit_main()
 			-q) QUIET=1 ;;
 			--debug) VERBOSE=1 ;;
 			--heads) HEADS="$1"; shift ;;
+			--search-heads) SEARCH_HEADS="$1"; shift ;;
 			--no-heads) NO_HEADS=1 ;;
 			--tags) TAGS="$1"; shift ;;
 			--no-tags) NO_TAGS=1 ;;
@@ -148,10 +151,22 @@ subsplit_publish()
 		subsplit_update
 	fi
 
-	if [ -z "$HEADS" ] && [ -z "$NO_HEADS" ]
+	if [ -z "$HEADS" ] && [ -z "$NO_HEADS" ] && [ -z "$SEARCH_HEADS" ]
 	then
 		# If heads are not specified and we want heads, discover them.
 		HEADS="$(git ls-remote origin 2>/dev/null | grep "refs/heads/" | cut -f3- -d/)"
+
+		if [ -n "$VERBOSE" ];
+		then
+			echo "${DEBUG} HEADS=\"${HEADS}\""
+		fi
+	fi
+
+  # search for matching heads
+	if [ ! -z "$SEARCH_HEADS" ] && [ -z "$HEADS" ] && [ -z "$NO_HEADS" ]
+	then
+		# If heads are not specified and we want heads, discover them.
+		HEADS="$(git ls-remote origin 2>/dev/null | grep "refs/heads/" | grep "${SEARCH_HEADS}" | cut -f3- -d/)"
 
 		if [ -n "$VERBOSE" ];
 		then


### PR DESCRIPTION
Hi,

We use `git-subsplit` for a while now. Thank you for the project!

There is now a request for us to split branches of a specific naming pattern (`release-xxx`). So I've made a small addition to the bash script to use a `--search-heads="pattern"` argument. All matching branches will be published.

In case you find it useful, here is also the pull request. Let me know if we need to change something.

Thank you!