### PR TITLE
Add habitat plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,0 +1,71 @@
+pkg_name=git-subsplit
+pkg_origin=dflydev
+pkg_maintainer="Beau Simensen <hello@dflydev.com>"
+pkg_license=("MIT")
+pkg_upstream_url=https://github.com/dflydev/git-subsplit
+
+pkg_build_deps=(
+  core/git
+)
+
+pkg_deps=(
+  core/bash
+)
+
+pkg_bin_dirs=(bin)
+
+
+# implement git-based dynamic version strings
+pkg_version() {
+  if [ -n "${pkg_last_tag}" ]; then
+    echo "${pkg_last_version}-git+${pkg_last_tag_distance}.${pkg_commit}"
+  else
+    echo "${pkg_last_version}-git+${pkg_commit}"
+  fi
+}
+
+
+# implement in-git build workflow
+do_before() {
+  do_default_before
+
+  # configure git repository
+  export GIT_DIR="${PLAN_CONTEXT}/../.git"
+
+  # load version information from git
+  pkg_commit="$(git rev-parse --short HEAD)"
+  pkg_last_tag="$(git describe --tags --abbrev=0 ${pkg_commit} || true 2>/dev/null)"
+
+  if [ -n "${pkg_last_tag}" ]; then
+    pkg_last_version=${pkg_last_tag#v}
+    pkg_last_tag_distance="$(git rev-list ${pkg_last_tag}..${pkg_commit} --count)"
+  else
+    pkg_last_version="0.0.0"
+  fi
+
+  # initialize pkg_version
+  update_pkg_version
+}
+
+do_unpack() {
+  mkdir "${CACHE_PATH}"
+  build_line "Extracting ${GIT_DIR}#${pkg_commit}"
+  git archive "${pkg_commit}" | tar -x --directory="${CACHE_PATH}"
+}
+
+do_build() {
+  pushd "${CACHE_PATH}" > /dev/null
+
+  build_line "Fixing interpreter"
+  sed -e "s#\#\!/usr/bin/env bash#\#\!$(pkg_path_for bash)/bin/bash#" --in-place "./git-subsplit.sh"
+
+  popd > /dev/null
+}
+
+do_install() {
+  cp -v "${CACHE_PATH}/git-subsplit.sh" "${pkg_prefix}/bin/git-subsplit"
+}
+
+do_strip() {
+  return 0
+}


### PR DESCRIPTION
This provides an easy way to install the command onto systems, and has the benefit of running git-subsplit under a consistent `bash` version

The habitat binary can be installed with this one-liner:

```bash
curl -s https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash
 ```

I've published a build to my own origin, which you can install like this:

```bash
hab pkg install jarvus/git-subsplit
```

The maintainer of this repo could sign into https://bldr.habitat.sh with their github account, register the origin `dflydev`, and configure habitat's public builder to automatically create new builds whenever the `master` branch in this repo is updated.

Alternatively, someone cloning this repository could just run:

```bash
hab pkg build .
sudo hab pkg install ./results/*.hart
```

Once the package is installed to a system, this command can be run to install the binary to the needed path:

```bash
sudo hab pkg binlink -d "$(git --exec-path)" jarvus/git-subsplit
```

## Final result

With a `dflydev` origin setup on bldr.habitat.org and linked to the repository, these commands could be used in a CI process at any time to quickly and consistently load the latest version:

```bash
# install habitat client binary
curl -s https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash

# install git-subsplit package
sudo hab pkg install dflydev/git-subsplit

# add to system's git subcommands
sudo hab pkg binlink -d "$(git --exec-path)" dflydev/git-subsplit
```

### Bonus points

Tag a release version on the master branch in this repo and the habitat build will pick it up